### PR TITLE
Add minimal requirements.txt for Django backend setup

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+Django>=4.2
+djangorestframework>=3.15
+firebase-admin>=6.2.0
+python-dotenv>=1.0.1
+requests>=2.32.0
+gunicorn>=21.2.0


### PR DESCRIPTION
- Adds a simplified `requirements.txt` under the backend directory.
- Includes core dependencies like Django, DRF, Firebase Admin, and dotenv.
- Helps contributors install all necessary packages with a single command.

Closes #12